### PR TITLE
Site-level wind risk based on multiple H-dominant layers

### DIFF
--- a/src/B_prebas.f90
+++ b/src/B_prebas.f90
@@ -142,7 +142,7 @@ real (kind=8) :: remhW_branch, remhW_croot,remhW_stem,remhWdb
 integer :: etmodel, gvRun, fertThin, ECMmod, oldLayer !not direct inputs anymore, but in prebasFlags fvec
 integer, intent(in) :: prebasFlags(6)
 REAL (kind=8)::  wrisk5, wrisk0, wrisk ! 5-year wind risk (suvanto output), pre-logit value, annual risk
-REAL (kind=8)::  wrisk_hdomlayers(nLayers), hthresh, htresh_ba !
+REAL (kind=8)::  hthresh, htresh_ba !
 
 REAL (kind=8):: wrisk5dd1, wrisk5dd2, wrisk5dd3 !5-year wind risk of each damage density class
 REAL (kind=8)::  V_tot, vdam ! vol of all layers, site-level damaged vol 

--- a/src/B_prebas.f90
+++ b/src/B_prebas.f90
@@ -142,6 +142,8 @@ real (kind=8) :: remhW_branch, remhW_croot,remhW_stem,remhWdb
 integer :: etmodel, gvRun, fertThin, ECMmod, oldLayer !not direct inputs anymore, but in prebasFlags fvec
 integer, intent(in) :: prebasFlags(6)
 REAL (kind=8)::  wrisk5, wrisk0, wrisk ! 5-year wind risk (suvanto output), pre-logit value, annual risk
+REAL (kind=8)::  wrisk_hdomlayers(nLayers), hthresh, htresh_ba !
+
 REAL (kind=8):: wrisk5dd1, wrisk5dd2, wrisk5dd3 !5-year wind risk of each damage density class
 REAL (kind=8)::  V_tot, vdam ! vol of all layers, site-level damaged vol 
 REAL (kind=8):: BAdist(nLayers) !disturbed BA per layer

--- a/src/B_prebas.f90
+++ b/src/B_prebas.f90
@@ -9,7 +9,7 @@ subroutine prebas(nYears,nLayers,nSp,siteInfo,pCrobas,initVar,thinning,output, &
      litterSize,soilCtotInOut,defaultThin,ClCut,energyCut,inDclct,&
      inAclct,dailyPRELES,yassoRun,energyWood,tapioPars,thdPer,limPer,&
      ftTapio,tTapio,GVout,thinInt, &
-   flagFert,nYearsFert,mortMod,pECMmod, & 
+   flagFert,nYearsFert,mortMod,pECMmod, &
    layerPRELES,LUEtrees,LUEgv, siteInfoDist, outDist, prebasFlags)
 
 
@@ -107,16 +107,16 @@ real (kind=8) :: wdistproc(7) !to replace siteinfodist
  real (kind=8) :: dens_thd, dens_lim, Hdom_lim ! thinning parameters
 
 !define varibles
- real (kind=8) :: sitetype, P0, age, meantemp, mintemp, maxtemp, rainfall, ETS 
+ real (kind=8) :: sitetype, P0, age, meantemp, mintemp, maxtemp, rainfall, ETS
  real (kind=8) :: H, D, B, Hc, Cw, Lc, N, Ntree, Ntot, dNtot
  real (kind=8) :: wf_treeKG, wf_STKG, sar_con, sar_ell, rc, ppow, sar, W_stem
  real (kind=8) :: lproj, leff, laPer_sar, keff, slc
  real (kind=8) :: hb, A, B2, beta0, beta1,beta2, betab !,betas
  real (kind=8) :: c,dHc,dH,dLc,g0,g1,g2,g3,g4,g5
- real (kind=8) :: npp, p_eff_all, gammaC, betaC, W_c, W_s, Wdb, Wsh,nppCost !nppCost is the npp used in growth that considers the cost of ECM to the tree 
+ real (kind=8) :: npp, p_eff_all, gammaC, betaC, W_c, W_s, Wdb, Wsh,nppCost !nppCost is the npp used in growth that considers the cost of ECM to the tree
  real (kind=8) :: p_eff, par_alfar, p, gpp_sp
  real (kind=8) :: s0,par_s0scale,par_sla0,par_tsla
- real (kind=8) :: age_factor,par_fAa,par_fAb,par_fAc ! Changes in fine root allocation for young seedlings, affecting beta0 and alfar 
+ real (kind=8) :: age_factor,par_fAa,par_fAb,par_fAc ! Changes in fine root allocation for young seedlings, affecting beta0 and alfar
  real (kind=8) :: weight, dNp,dNb,dNs,perVmort
  real (kind=8) :: W_wsap, respi_m, respi_tot, V_scrown, V_bole, V, Vold
  real (kind=8) :: coeff(nLayers), denom,W_froot,W_croot, lit_wf,lit_froot
@@ -142,10 +142,9 @@ real (kind=8) :: remhW_branch, remhW_croot,remhW_stem,remhWdb
 integer :: etmodel, gvRun, fertThin, ECMmod, oldLayer !not direct inputs anymore, but in prebasFlags fvec
 integer, intent(in) :: prebasFlags(6)
 REAL (kind=8)::  wrisk5, wrisk0, wrisk ! 5-year wind risk (suvanto output), pre-logit value, annual risk
-REAL (kind=8)::  hthresh, htresh_ba !
-
+REAL (kind=8)::  wrisk_hdomlayers(nLayers), hthresh, htresh_ba !
 REAL (kind=8):: wrisk5dd1, wrisk5dd2, wrisk5dd3 !5-year wind risk of each damage density class
-REAL (kind=8)::  V_tot, vdam ! vol of all layers, site-level damaged vol 
+REAL (kind=8)::  V_tot, vdam ! vol of all layers, site-level damaged vol
 REAL (kind=8):: BAdist(nLayers) !disturbed BA per layer
 
 
@@ -160,7 +159,7 @@ ECMmod = int(prebasFlags(5))
 if(prebasFlags(6)==0) disturbanceON = .FALSE.
 if(prebasFlags(6)==1) disturbanceON = .TRUE.
 
-! 
+!
 ! outDist(1,1) = prebasFlags(6)
 ! outDist(1,2) = siteInfoDist(2)
 
@@ -194,10 +193,10 @@ Reineke(:) = 0.
 ETSmean = sum(ETSy)/nYears
 
 ! Fill in model output structure with initial values and ids.
- modOut(:,1,:,1) = siteInfo(1)  !! assign siteID 
+ modOut(:,1,:,1) = siteInfo(1)  !! assign siteID
  ! modOut(1,2,:,1) = initVar(8,:)  !! assign initial gammaC values !!newX
  modOut(1,11,:,1) = initVar(3,:) ! height of trees
- modOut(1,16,:,1) = initVar(7,:) 
+ modOut(1,16,:,1) = initVar(7,:)
  ! modOut(1,12,:,1) = initVar(4,:)
  ! modOut(1,13,:,1) = initVar(5,:)
  modOut(1,14,:,1) = initVar(6,:)
@@ -219,7 +218,7 @@ ETSmean = sum(ETSy)/nYears
   modOut(1,17,i,1) = modOut(1,13,i,1)/(pi*((modOut(1,12,i,1)/2/100)**2))
   modOut(1,35,i,1) = modOut(1,13,i,1)/modOut(1,17,i,1)
   else
-  modOut(1,17,i,1) = 0. 
+  modOut(1,17,i,1) = 0.
   modOut(1,35,i,1) = 0.
   endif
 
@@ -228,7 +227,7 @@ ETSmean = sum(ETSy)/nYears
 !######! SIMULATION START !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 do year = 1, (nYears)
   VmortDist=0.
-  
+
 siteInfoDist(2) = siteInfoDist(2)+1 !counter for time since thinning (wind disturbance model predictor)
 
 !!!! check if clearcut occured. If yes initialize forest (start)
@@ -255,10 +254,10 @@ siteInfoDist(2) = siteInfoDist(2)+1 !counter for time since thinning (wind distu
     modOut(year,17,ijj,1) = modOut(year,13,ijj,1)/(pi*((modOut(year,12,ijj,1)/2/100)**2))
     modOut(year,35,ijj,1) =  modOut(year,13,ijj,1)/modOut(year,17,ijj,1)
     else
-    modOut(year,17,ijj,1) = 0. 
-    modOut(year,35,ijj,1) = 0. 
+    modOut(year,17,ijj,1) = 0.
+    modOut(year,35,ijj,1) = 0.
     endif
-   
+
   siteType = modOut(year,3,ijj,1) !siteInfo(3)
   !!set parameters
   par_betab = pCrobas(13,int(initVar(1,ijj)))
@@ -269,7 +268,7 @@ siteInfoDist(2) = siteInfoDist(2)+1 !counter for time since thinning (wind distu
   par_mr = pCrobas(9,int(initVar(1,ijj)))
   par_mw = pCrobas(10,int(initVar(1,ijj)))
   par_fAa = pCrobas(45,int(initVar(1,ijj)))
-  par_fAb = pCrobas(46,int(initVar(1,ijj))) 
+  par_fAb = pCrobas(46,int(initVar(1,ijj)))
   par_fAc = pCrobas(47,int(initVar(1,ijj)))
   par_c = pCrobas(7,int(initVar(1,ijj)))
   par_rhof = pCrobas(15,int(initVar(1,ijj)))
@@ -277,30 +276,30 @@ siteInfoDist(2) = siteInfoDist(2)+1 !counter for time since thinning (wind distu
   par_S_branchMod = pCrobas(27,int(initVar(1,ijj)))
   gammaC = 0. !initVarX(8,)
   ! Tbd = 10 !!!!to include in the parameters
-  
+
   !!set variables
   A = modOut(year,16,ijj,1)
   ba = modOut(year,13,ijj,1)
   d = modOut(year,12,ijj,1)
   N = ba/(pi*((d/2/100)**2))
   h = modOut(year,11,ijj,1)
-  
-  age_factor = (1. - (1. - par_fAa)/ (1. + exp((par_fAb - h)/par_fAc)))/par_fAa    
+
+  age_factor = (1. - (1. - par_fAa)/ (1. + exp((par_fAb - h)/par_fAc)))/par_fAa
   par_alfar = modOut(year,3,ijj,2) * age_factor
   ! par_alfar = pCrobas(int(20+min(siteType,5.)),int(initVar(1,ijj))) * age_factor
   par_rhor = par_alfar * par_rhof
-  
+
   hc = modOut(year,14,ijj,1)
   B = ba/N
   Lc = h - hc
   betab =  par_betab * Lc**(par_x-1)
   beta0 = par_beta0 * age_factor
-  beta1 = (beta0 + betab + par_betas) 
-  beta2 = 1. - betab - par_betas     
+  beta1 = (beta0 + betab + par_betas)
+  beta2 = 1. - betab - par_betas
   betaC = (beta1 + gammaC * beta2) / par_betas
   wf_STKG = par_rhof * A * N
   W_froot = par_rhor * A * N  !!to check  ##newX
-  W_wsap = par_rhow * A * N * (beta1 * h + beta2 * hc) 
+  W_wsap = par_rhow * A * N * (beta1 * h + beta2 * hc)
   W_c = par_rhow * A * N * hc !sapwood stem below Crown
   W_s = par_rhow * A * N * par_betas * Lc !sapwood stem within crown
   W_branch =  par_rhow * A * N * betab * Lc !branches biomass
@@ -311,7 +310,7 @@ siteInfoDist(2) = siteInfoDist(2)+1 !counter for time since thinning (wind distu
   Wdb = 0.
   W_stem = W_c + W_s + Wsh
   V = W_stem / par_rhow
-  
+
   modOut(year,33,ijj,1) = wf_STKG
   modOut(year,25,ijj,1) = W_froot
   modOut(year,47,ijj,1) = W_wsap
@@ -323,14 +322,14 @@ siteInfoDist(2) = siteInfoDist(2)+1 !counter for time since thinning (wind distu
   modOut(year,51,ijj,1) = Wdb
   modOut(year,31,ijj,1) = W_stem
   modOut(year,30,ijj,1) = V
-  
+
    enddo
    do ki = 1,int(Ainit)
     do ijj = 1,nLayers
      modOut((year-Ainit+ki),7,ijj,1) = ki !#!#
      modOut((year-Ainit+ki),4,ijj,1) = initVar(1,ijj) !#!#
     enddo
-   enddo  
+   enddo
   yearX = 0
   endif
 !!!! check if clearcut occured. If yes initialize forest (end)
@@ -354,7 +353,7 @@ siteInfoDist(2) = siteInfoDist(2)+1 !counter for time since thinning (wind distu
     domSp = maxloc(valX)
      layerX(ij) = int(domSp(1))
     valX(layerX(ij)) = -999.
-  
+
      Ntot = sum(STAND_all(17,layerX(1:ij)))
      B = sum(STAND_all(35,layerX(1:ij))*STAND_all(17,layerX(1:ij)))/Ntot   !!!!!!!!!#####changed
    ! B = STAND_all(35,layerX(1:ij))/STAND_all(17,layerX(1:ij))   !!!!!!!!!#####changed
@@ -417,11 +416,11 @@ do ij = 1 , nLayers     !loop Species
  par_fAc = param(47)
 ! do siteNo = 1, nSites  !loop sites
 
-    !!!!update kRein and cR   
-   !!!!update par_kRein as a function of sitetype if parameters (param(50>-999.))) are are provided 
-   if(param(50)>-999.d0) call linearUpdateParam(param(50:51),stand(3),par_kRein) 
-   !!!!update par_cR as a function of sitetype if parameters (param(52>-999.))) are are provided 
-   if(param(52)>-999.d0) call linearUpdateParam(param(52:53),stand(3),par_cR) 
+    !!!!update kRein and cR
+   !!!!update par_kRein as a function of sitetype if parameters (param(50>-999.))) are are provided
+   if(param(50)>-999.d0) call linearUpdateParam(param(50:51),stand(3),par_kRein)
+   !!!!update par_cR as a function of sitetype if parameters (param(52>-999.))) are are provided
+   if(param(52)>-999.d0) call linearUpdateParam(param(52:53),stand(3),par_cR)
 
 ! initialize site variables
 !  sitetype = STAND(3)
@@ -484,7 +483,7 @@ do ij = 1 , nLayers     !loop Species
     laPer_sar = wf_treeKG * par_sla / sar !leaf area per tree  /  crown surface area
     keff = 0.4 * (1. - exp( - par_k / 0.4 * laPer_sar)) / laPer_sar !effective extinction coefficient    }
   endif
-  
+
   !projected leaf area on the STAND -----------------------------------
   if (wf_STKG>0.) then
    lproj = par_sla * wf_STKG / 10000.
@@ -516,7 +515,7 @@ end do !!!!!!!end loop layers
 if (year <= maxYearSite) then
   nSpec = nSp
   ll = nLayers
-  
+
   domSp = maxloc(STAND_all(13,:))
   layer = int(domSp(1))
   siteType = modOut(year,3,layer,1) !siteInfo(3)
@@ -540,9 +539,9 @@ if (year <= maxYearSite) then
   else
       Ainit = max(nint(6. + 2*sitetype - 0.005*(sum(modOut(year:(year+9),5,1,1))/10.) + 2.25 + 2.0),2)!! + 2.0 to account for the delay between planting and clearcut
   endif
-  yearX = Ainit + year 
+  yearX = Ainit + year
    endif
-   
+
    !!!ground vegetation
    !!!fapar_gv compute fapar, biomasses and litter of gv with routine
    if(gvRun==1) then
@@ -574,7 +573,7 @@ if(isnan(fAPARgvX)) fAPARgvX = 0.
 
    if(layerPRELES == 0) then
 
-  !run preles 
+  !run preles
      call preles(weatherPRELES(year,:,:),DOY,fAPARprel,prelesOut, pars, &
     dailyPRELES((1+((year-1)*365)):(365*year),1), &  !daily GPP
     dailyPRELES((1+((year-1)*365)):(365*year),2), &  !daily ET
@@ -584,19 +583,19 @@ if(isnan(fAPARgvX)) fAPARgvX = 0.
    !store ET of the ECOSYSTEM!!!!!!!!!!!!!!
      STAND_all(22,:) = prelesOut(2)    !ET
    ! STAND_all(40,:) = prelesOut(15)  !aSW
-   ! STAND_all(41,:) = prelesOut(16)  !summerSW 
-  
+   ! STAND_all(41,:) = prelesOut(16)  !summerSW
+
   !store GPP
-     GVout(year,3) = prelesOut(1) * fAPARgvX/fAPARsite! GV Photosynthesis in g C m-2 
+     GVout(year,3) = prelesOut(1) * fAPARgvX/fAPARsite! GV Photosynthesis in g C m-2
      STAND_all(10,:) = prelesOut(1)/1000. * fAPARtrees/fAPARsite * coeff! trees Photosynthesis in g C m-2 (converted to kg C m-2)
 
-!initialize for next year  
+!initialize for next year
      pars(24) = prelesOut(3);siteInfo(4) = prelesOut(3)!SWinit
      pars(25) = prelesOut(13); siteInfo(5) = prelesOut(13) !CWinit
      pars(26) = prelesOut(4); siteInfo(6) = prelesOut(4) !SOGinit
      pars(27) = prelesOut(14); siteInfo(7) = prelesOut(14) !Sinit
    endif
-   
+
    if(layerPRELES == 1) then
     fAPARlayers(1:nLayers) = fAPARtrees * coeff
   fAPARlayers(1+nLayers) = fAPARgvX
@@ -613,23 +612,23 @@ if(isnan(fAPARgvX)) fAPARgvX = 0.
   !store ET of the ECOSYSTEM!!!!!!!!!!!!!!
     STAND_all(22,:) = prelesOut(2)    !ET
    ! STAND_all(40,:) = prelesOut(15)  !aSW
-   ! STAND_all(41,:) = prelesOut(16)  !summerSW 
+   ! STAND_all(41,:) = prelesOut(16)  !summerSW
   !store GPP
     GVout(year,3) = prelesOut(1) * fAPARlayers(1+nLayers)/fAPARsite * &
             LUElayers(1+nLayers)/LUEsite !!!GV photosynthesis
-            
+
      STAND_all(10,:) = prelesOut(1)/1000. * fAPARlayers(1:nLayers)/fAPARsite * &
               LUElayers(1:nLayers)/LUEsite! trees Photosynthesis in g C m-2 (converted to kg C m-2)
 
 
-!initialize for next year  
+!initialize for next year
      pars(24) = prelesOut(3);siteInfo(4) = prelesOut(3)!SWinit
      pars(25) = prelesOut(13); siteInfo(5) = prelesOut(13) !CWinit
      pars(26) = prelesOut(4); siteInfo(6) = prelesOut(4) !SOGinit
      pars(27) = prelesOut(14); siteInfo(7) = prelesOut(14) !Sinit
 
    endif
-   
+
     outt(46,1,2)  = prelesOut(7)
 
 endif
@@ -641,7 +640,7 @@ do ij = 1 , nLayers
  species = int(max(1.,stand(4)))
  param = pCrobas(:,species)
  sitetype=stand(3)
- 
+
    !!!reset annual litterfall
 stand_all(26:29,ij) = 0.
 stand(26:29) = 0.
@@ -700,11 +699,11 @@ exud(ij) = 0.d0
  par_fAc = param(47)
 ! do siteNo = 1, nSites  !start site loop
 
-    !!!!update kRein and cR   
-   !!!!update par_kRein as a function of sitetype if parameters (param(50>-999.))) are are provided 
-   if(param(50)>-999.d0) call linearUpdateParam(param(50:51),stand(3),par_kRein) 
-   !!!!update par_cR as a function of sitetype if parameters (param(52>-999.))) are are provided 
-   if(param(52)>-999.d0) call linearUpdateParam(param(52:53),stand(3),par_cR) 
+    !!!!update kRein and cR
+   !!!!update par_kRein as a function of sitetype if parameters (param(50>-999.))) are are provided
+   if(param(50)>-999.d0) call linearUpdateParam(param(50:51),stand(3),par_kRein)
+   !!!!update par_cR as a function of sitetype if parameters (param(52>-999.))) are are provided
+   if(param(52)>-999.d0) call linearUpdateParam(param(52:53),stand(3),par_cR)
 
 if (year > maxYearSite) then
   STAND(2) = 0. !!newX
@@ -778,8 +777,8 @@ if (N>0.) then
 !  par_mr = par_mr0 * p0 / p0_ref
 !  par_mw = par_mw0 * p0 / p0_ref
 
-  
-  ! par_H0 = par_H0max * (1 - exp(-par_kH * ETS/par_alfar)) !!! attempt to improve model for diameter/heigh allocation, not used currently. 
+
+  ! par_H0 = par_H0max * (1 - exp(-par_kH * ETS/par_alfar)) !!! attempt to improve model for diameter/heigh allocation, not used currently.
   ! theta = par_thetaMax / (1. + exp(-(H - par_H0)/(par_H0*par_gamma)))   !!!! see above, get zero now
   theta = par_thetaMax
 
@@ -811,7 +810,7 @@ if (N>0.) then
         s0 = 0.
     endif
   gpp_sp = max(0.,(s0 - par_s1 * H) * wf_STKG / 10000.)
-  
+
         !---------------------------------------
         ! DYNAMIC GROWTH MODEL STARTS
         !Updating the tree H, D, Hc and Cw for the next year, according to the method by Valentine & Makela (2005)
@@ -856,16 +855,16 @@ if (N>0.) then
       endif
       nppCost = max(0.,(gpp_sp - Cost_m / 10000.) / (1.+par_c))  !!newX
       npp = max(0.,(gpp_sp - Respi_m / 10000.) / (1.+par_c))  !!newX
-      
-      
+
+
       Respi_tot = gpp_sp - npp
          ! ! litter fall in the absence of thinning
       S_fol = S_fol + wf_STKG / par_vf  !foliage litterfall
       S_fr  = S_fr + W_froot / par_vr  !fine root litter
     S_branch = max(0.,S_branch + Wdb/Tdb)
-    
+
     ! S_branch = S_branch + N * par_rhow * betab * A * (dHc + theta*Lc)
-      
+
         !Height growth-----------------------
     f1 = nppCost*10000 - (wf_STKG/par_vf) - (W_froot/par_vr) - (theta * W_wsap)
     f2 = (par_z* (wf_STKG + W_froot + W_wsap)* (1-gammaC) + par_z * gammaC * (W_c + &
@@ -873,7 +872,7 @@ if (N>0.) then
     dH = max(0.,((H-Hc) * f1/f2))
     Gf = par_z * wf_STKG/(H-Hc) * (1-gammac)*dH
     Gr = par_z * W_froot/(H-Hc) * (1-gammac)*dH
-    
+
     if(f1 < 0.) then
       dH = 0.
       mort = 888.
@@ -885,13 +884,13 @@ if (N>0.) then
       mort = 888.
     endif
 
-  
+
  !-----------------------------------
         !crown rise
 !         if(H - Hc > par_Cr2*100./sqrt(N)) then
 !        if(2.*hb > 100./sqrt(N) ) then
         dHc = min(gammaC * dH,(H - Hc))
-    
+
 if(time==1)then
       dHcCum = 0.
       dHCum = 0.
@@ -915,10 +914,10 @@ endif
                 dA = 0.
                 dB = 0.
             endif
-            
-! Calculate change rates for non-living wood   - DECLARE dWsh etc...          
+
+! Calculate change rates for non-living wood   - DECLARE dWsh etc...
             dWsh = max(0.,par_rhow * par_z * A/Lc * dHc * Hc * N  + theta*(W_c + W_s))
-            dW_bh = max(0.,W_bs*theta - W_bh * gammaC * dH / Lc) 
+            dW_bh = max(0.,W_bs*theta - W_bh * gammaC * dH / Lc)
             dW_crh = max(0.,W_crs*theta + par_z * W_c * beta0 / Lc * gammaC * dH)
             dWdb = max(0.,W_branch/Lc * par_zb * gammaC * dH - Wdb/Tdb)
 
@@ -927,12 +926,12 @@ endif
           A = A + step * dA
           B = B + step * dB
       Hc = Hc + step * dHc
-          
+
           Wsh = Wsh + dWsh * step
           W_bh = W_bh + dW_bh * step
       W_crh = W_crh + dW_crh * step
       Wdb = Wdb + dWdb * step
-          
+
 ! Update dependent variables
       wf_treeKG = par_rhof * A
       wf_STKG = N * wf_treeKG
@@ -962,7 +961,7 @@ endif
     V = W_stem / par_rhow
     W_branch = W_bs + W_bh
     W_croot = W_crs + W_crh
-    
+
   age = age + step
 
   STAND(2) = gammaC
@@ -1073,14 +1072,14 @@ endif
      thinning(countThinning,7) = Hc * thinning(countThinning,7)
     endif
      endif
-     
+
      !!!check if ingrowth and calculate the number of trees
-     if(D==0.d0 .and. H==0.d0 .and. thinning(countThinning,6)==-777.d0) then 
+     if(D==0.d0 .and. H==0.d0 .and. thinning(countThinning,6)==-777.d0) then
       BA = pi*((0.5d0/200.d0)**2.d0)*min((500.d0/minFapar),4000.d0)
      else
       BA = thinning(countThinning,6)
      endif
-     
+
      if (thinning(countThinning,4) /= -999.) H = thinning(countThinning,4)
      if (thinning(countThinning,7) /= -999.) stand(14) = thinning(countThinning,7)
      if (thinning(countThinning,5) /= -999.) D = thinning(countThinning,5)
@@ -1109,7 +1108,7 @@ endif
      beta1 = (beta0 + betab + par_betas) !!newX
      beta2 = 1. - betab - par_betas     !!newX
      betaC = (beta1 + gammaC * beta2) / par_betas
-     
+
      !!!reinitialize the stand and some variables when the thinning matrix is used to initialize the stand in the middle of the runs(start)
      if(Nold==0.) then
       flagInitWithThin = .true.
@@ -1120,7 +1119,7 @@ endif
       yearX = 0.
      endif
      !!!reinitialize Nold and some variables when the thinning matrix is used to initialize the stand (end)
-      
+
       if(isnan(stand(50))) stand(50) = 0
       if(isnan(stand(53))) stand(53) = 0
       if(isnan(stand(54))) stand(54) = 0
@@ -1208,7 +1207,7 @@ endif
     stand(12) = D
     stand(13) = BA
     stand(16) = A
-    stand(14) = Hc  
+    stand(14) = Hc
     stand(17) = N
     stand(26) = S_fol
     stand(27) = S_fr
@@ -1232,7 +1231,7 @@ endif
     endif
   ! endif
   countThinning = countThinning + 1
- 
+
    End If
  End If
    STAND_all(:,ij)=STAND
@@ -1262,24 +1261,24 @@ endif
   thinClx(year,2) = 1 !flag for clearcut
    !if fertilization at thinning is active reset flagFert
   if(fertThin > 0) then
-  flagFert = 0  
+  flagFert = 0
   endif
-  
+
   if(oldLayer==1) then !if oldLayer
   !!check dominant layer
    ! domSp = maxloc(STAND_all(13,1:(nLayers - 1)))
    ! layer = int(domSp(1))
-   
+
    !set siteType and alfar for old layer
   modOut(:,3,nLayers,1) = modOut(year,3,species,1)
   modOut(:,3,nLayers,2) = modOut(year,3,species,2)
   outt(3,nLayers,:) = modOut(year,3,species,1:2)
-    
+
   !!!!calculate percentage of trees remaining after clearcut(pDomRem)
   call random_number(randX)
    pDomRem =   max((randX*5.+5.)/100.* &  !!randomly sample between 5 and 10 %
       sum(stand_all(13,1:ll))/stand_all(13,layer),0.05)
-   
+
   !update old layer
    stand_all(:,nLayers) = stand_all(:,layer)
    stand_all(42,nLayers) = 0.
@@ -1295,7 +1294,7 @@ endif
 
   !!!implement clearcut by layer (start) (not for old layer in oldLayer sceario)
    do ij = 1, ll
-   
+
     outt((/9,10,13,16,17,18,24,25,30,31,32,33/),ij,2) = outt((/9,10,13,16,17,18,24,25,30,31,32,33/),ij,2) + &
                     stand_all((/9,10,13,16,17,18,24,25,30,31,32,33/),ij)
   outt((/6,7,8,11,12,14,15,19,20,21,22,23,26,27,28,29,34,35,36,37,38,39,40,41,42,43,44,45,47,48,49,50,51,52,53,54/),ij,2) = &
@@ -1321,7 +1320,7 @@ if(pCrobas(2,species)>0.) energyWood(year,ij,1) = energyWood(year,ij,2) / pCroba
   !energyCut
     stand_all(2,ij) = 0. !!newX
     stand_all(7,ij) = 0.
-  stand_all(8,ij) = 0.  
+  stand_all(8,ij) = 0.
     stand_all(10:17,ij) = 0.
     stand_all(19:21,ij) = 0.
     stand_all(23:38,ij) = 0.
@@ -1354,7 +1353,7 @@ if(pCrobas(2,species)>0.)   energyWood(year,ij,1) = energyWood(year,ij,2) / pCro
     stand_all(51,ij) + (0.3 * (1-energyRatio)+0.7) * stand_all(32,ij) *0.83 + &
     stand_all(31,ij)* (1-harvRatio) * (1-energyRatio)))
    S_wood = (0.3 * (1-energyRatio)+0.7) * stand_all(32,ij) *0.17+ stand_all(29,ij) !(1-harvRatio) takes into account of the stem residuals after clearcuts
-      
+
   else
    S_branch = max(0.,(stand_all(51,ij)+stand_all(24,ij)+stand_all(28,ij)+stand_all(32,ij)* 0.83 +&
       stand_all(31,ij)* (1-harvRatio)))
@@ -1374,7 +1373,7 @@ if(pCrobas(2,species)>0.)   energyWood(year,ij,1) = energyWood(year,ij,2) / pCro
     stand_all(27,ij) = S_fr
     stand_all(28,ij) = S_branch
     stand_all(29,ij) = S_wood
-  
+
    enddo !!!implement clearcut by layer (end)
   endif !!!end if oldLayer
  endif
@@ -1402,14 +1401,14 @@ if(defaultThin == 1.) then
  Hdom = pCrobas(42,species)*exp(-1/max((H-1.3),0.001))+pCrobas(43,species)*H
  Ntot = sum(STAND_all(17,:))
   !! here we decide what thinning function to use; 3 = tapioThin, 2 = tapioFirstThin, 1 = tapioTend
- call chooseThin(species, siteType, ETSmean, Ntot, Hdom, tTapio, ftTapio, thinningType) 
+ call chooseThin(species, siteType, ETSmean, Ntot, Hdom, tTapio, ftTapio, thinningType)
  ! thinx = thinningType
 
- if(thinningType == 3.) then   
-  call tapioThin(pCrobas(28,species),siteType,ETSmean,Hdom,tapioPars,BAtapio,thdPer,limPer)  
+ if(thinningType == 3.) then
+  call tapioThin(pCrobas(28,species),siteType,ETSmean,Hdom,tapioPars,BAtapio,thdPer,limPer)
   BA_lim = BAtapio(1) ! BA limit to start thinning
   BA_thd = BAtapio(2) ! BA after thinning
-  if(BA_tot > BA_lim) then 
+  if(BA_tot > BA_lim) then
     doThin = .true.
   else
     doThin = .false.
@@ -1419,7 +1418,7 @@ if(defaultThin == 1.) then
   Hdom_lim = tapioOut(1) ! Hdom limit to start thinning
   dens_lim = tapioOut(2) ! density limit to start thinning; both need to be reached
   dens_thd = tapioOut(3) ! density after thinning
-  if(Hdom > Hdom_lim .and. Ntot > dens_lim) then 
+  if(Hdom > Hdom_lim .and. Ntot > dens_lim) then
     doThin = .true.
   else
     doThin = .false.
@@ -1429,21 +1428,21 @@ if(defaultThin == 1.) then
   Hdom_lim = tapioOut(1)! Hdom limit to start thinning
   dens_lim = tapioOut(2) ! density limit to start thinning; both need to be reached
   dens_thd = tapioOut(3) ! density after thinning
-  if(Hdom > Hdom_lim .and. Ntot > dens_lim) then 
+  if(Hdom > Hdom_lim .and. Ntot > dens_lim) then
     doThin = .true.
   else
     doThin = .false.
   endif
  endif
- 
+
 
 
  if(doThin) then
-   
+
    siteInfoDist(2) = 0 !reset counter for time since thinning (wind dist model predictor)
 
  !!!fertilization at thinning
-  if(fertThin == 3 .and. flagFert<1 .and. siteType>3. .and. siteType<6.) then 
+  if(fertThin == 3 .and. flagFert<1 .and. siteType>3. .and. siteType<6.) then
     flagFert=1
 
     yearsFert = max(1,min((nYears) - year,nYearsFert))
@@ -1505,23 +1504,23 @@ if(defaultThin == 1.) then
     par_rhof = par_rhof1 * stand_all(5,ij) + par_rhof2
   Nold = stand_all(17,ij)
 
-    !!!!update kRein and cR   
-   !!!!update par_kRein as a function of sitetype if parameters (param(50>-999.))) are are provided 
-   if(param(50)>-999.d0) call linearUpdateParam(param(50:51),stand(3),par_kRein) 
-   !!!!update par_cR as a function of sitetype if parameters (param(52>-999.))) are are provided 
-   if(param(52)>-999.d0) call linearUpdateParam(param(52:53),stand(3),par_cR) 
+    !!!!update kRein and cR
+   !!!!update par_kRein as a function of sitetype if parameters (param(50>-999.))) are are provided
+   if(param(50)>-999.d0) call linearUpdateParam(param(50:51),stand(3),par_kRein)
+   !!!!update par_cR as a function of sitetype if parameters (param(52>-999.))) are are provided
+   if(param(52)>-999.d0) call linearUpdateParam(param(52:53),stand(3),par_cR)
 
-  
+
   if(thinningType == 1. .or. thinningType == 2.) then
     ! N = number of trees in the current layer after thinning
     N = (stand_all(17,ij)/Ntot) * dens_thd
     H = stand_all(11,ij)
     D = stand_all(12,ij)
     BA = N*pi*(D/2./100.)**2.
-  else if(thinningType == 3.) then 
+  else if(thinningType == 3.) then
     BA_tot = BA_thd
     BA = BAr(ij) * BA_thd
-        if(thinInt > 0.) then 
+        if(thinInt > 0.) then
       H = stand_all(11,ij) * 0.9
       D = stand_all(12,ij) * 0.9
     else
@@ -1536,10 +1535,10 @@ if(defaultThin == 1.) then
     N = BA/(pi*((D/2./100.)**2.))
   endif
 
-  stand_all(13,ij) = BA  
+  stand_all(13,ij) = BA
     Nthd = max(0.,(Nold - N))
     Hc = min(stand_all(14,ij),0.9*H)
-  if(siteInfo(1)==719400.) then 
+  if(siteInfo(1)==719400.) then
   endif
 
   Wdb = stand_all(51,ij)
@@ -1548,11 +1547,11 @@ if(defaultThin == 1.) then
     wf_STKG_old = stand_all(33,ij)
     W_stem_old = stand_all(31,ij)
     B = BA/N
-    A = stand_all(16,ij) * B/stand_all(35,ij) !!! to check 
+    A = stand_all(16,ij) * B/stand_all(35,ij) !!! to check
     hb = par_betab * Lc ** par_x
     Cw = 2. * hb
-  
-    
+
+
   !!update biomasses
   age_factor = (1. - (1. - par_fAa)/ (1. + exp((par_fAb - h)/par_fAc)))/par_fAa
   par_alfar = modOut(year,3,ij,2) * age_factor
@@ -1620,7 +1619,7 @@ if(pCrobas(2,species)>0.) energyWood(year,ij,1) = energyWood(year,ij,2) / pCroba
      S_wood = max(0.,stand_all(29,ij)  + (stand_all(32,ij) - W_croot) * 0.17)
   endif
   !energyCut
-  
+
     outt(11,ij,2) = STAND_tot(11)
     outt(12,ij,2) = STAND_tot(12)
     outt(13,ij,2) = outt(13,ij,2) + STAND_tot(13) - BA
@@ -1686,8 +1685,8 @@ modOut((year+1),4,:,:) = outt(4,:,:) !update species
 modOut((year+1),7,:,:) = outt(7,:,:)
 modOut((year+1),9:nVar,:,:) = outt(9:nVar,:,:)
 
- if(oldLayer==1) then 
-  modOut((year+1),:,nLayers,:) = outt(:,nLayers,:) 
+ if(oldLayer==1) then
+  modOut((year+1),:,nLayers,:) = outt(:,nLayers,:)
  endif
 !!!!run Yasso
  if(yassoRun==1.) then
@@ -1698,14 +1697,14 @@ modOut((year+1),9:nVar,:,:) = outt(9:nVar,:,:)
 
    species = int(max(1.,modOut((year+1),4,ijj,1)))
    call compAWENH(Lf(ijj),folAWENH(ijj,:),pAWEN(1:4,species))   !!!awen partitioning foliage
-   if(GVrun==1 .and. ijj==1) then 
+   if(GVrun==1 .and. ijj==1) then
     folAWENH(ijj,1:4) = folAWENH(ijj,1:4) + AWENgv       !!!add AWEN gv to 1st layer
    endif
-   
+
    !!!ECMmodelling.
    !add W for all layer to W folAWENH(ijj,2) = folAWENH(ijj,2) + exud(ijj) !!!ECMmodelling.  exud(ijj)=0 if ECMmod= 0
    folAWENH(ijj,2) = folAWENH(ijj,2) + exud(ijj) !!!ECMmodelling
-      
+
    call compAWENH(Lb(ijj),fbAWENH(ijj,:),pAWEN(5:8,species))   !!!awen partitioning branches
    call compAWENH(Lst(ijj),stAWENH(ijj,:),pAWEN(9:12,species))         !!!awen partitioning stems
 
@@ -1719,12 +1718,12 @@ modOut((year+1),9:nVar,:,:) = outt(9:nVar,:,:)
 
   soilCtot(year+1) = sum(soilC(year+1,:,:,:))
  endif !end yassoRun if
- 
+
 enddo !end year loop
 
 !soil and harvested volume outputs
-modOut(:,37,:,1) = modOut(:,30,:,2) * harvRatio!! harvRatio takes into account the residuals left in the soil 
-modOut(:,38,:,1) = modOut(:,31,:,2) * harvRatio!! harvRatio takes into account the residuals left in the soil 
+modOut(:,37,:,1) = modOut(:,30,:,2) * harvRatio!! harvRatio takes into account the residuals left in the soil
+modOut(:,38,:,1) = modOut(:,31,:,2) * harvRatio!! harvRatio takes into account the residuals left in the soil
 
 do year = 1,(nYears+1)
   do ijj = 1, nLayers
@@ -1750,14 +1749,14 @@ enddo
     modOut(2:(nYears+1),26,:,1)/10. + modOut(2:(nYears+1),27,:,1)/10. + &
     modOut(2:(nYears+1),28,:,1)/10. + modOut(2:(nYears+1),29,:,1)/10.
   if(GVrun==1) modOut(2:(nYears+1),45,1,1) = modOut(2:(nYears+1),45,1,1) + GVout(:,2)/10.  !/10 coverts units to g C m−2 y−1
-  
-modOut(:,46,:,1) = modOut(:,44,:,1) - modOut(:,9,:,1) - modOut(:,45,:,1) 
+
+modOut(:,46,:,1) = modOut(:,44,:,1) - modOut(:,9,:,1) - modOut(:,45,:,1)
 
 !!!!ground vegetation Add Npp ground vegetation to the NEE first layer
 !!!calculate state of GV at the last year
-if(GVrun==1) then 
+if(GVrun==1) then
  stand_all = modOut((nYears+1),:,:,1)
- do ij = 1, nLayers 
+ do ij = 1, nLayers
   if(stand_all(4,ij)==0.) stand_all(4,ij)=1.
  enddo
  call Ffotos2(stand_all,nLayers,nSpec,pCrobas,&
@@ -1771,12 +1770,12 @@ call fAPARgv(fAPARtrees, ETSmean, siteInfo(3), lastGVout(1), lastGVout(2), &
   ! GVout(1:(nYears-1),4) = GVout(2:(nYears),4)
   ! GVout(nYears,4) = lastGVout(4)
  else  !!!when nYears ==1 in the region multi prebas
-  
+
   GVout(nYears,5) = (lastGVout(4) - GVout((nYears),4) + GVout((nYears),2))/10.
   ! GVout(nYears,4) = lastGVout(4)
   endif
   modOut(2:(nYears+1),46,1,1) = modOut(2:(nYears+1),46,1,1) + GVout(:,5)
- 
+
 endif
 !!!calculate deadWood using Gompetz function (Makinen et al. 2006)!!!!
  do year = 2,(nYears +1)
@@ -1791,7 +1790,7 @@ endif
                  pCrobas(37,species)*D + pCrobas(44,species)))
     if(perVmort > pCrobas(49,species)) then
        modOut((year+i),8,ij,1) = modOut((year+i),8,ij,1) + Vmort * perVmort
-      endif  
+      endif
    enddo
    endif
   enddo

--- a/src/B_prebas.f90
+++ b/src/B_prebas.f90
@@ -39,6 +39,17 @@ real (kind=8) :: sc1vols(87), sc2vols(15), sc3vols(6)
 real (kind=8) :: wriskLayers(nLayers, 6)
 !!! wind dist / salvlog development
 real (kind=8) :: wdistproc(7) !to replace siteinfodist
+REAL (kind=8)::  wrisk5, wrisk0, wrisk ! 5-year wind risk (suvanto output), pre-logit value, annual risk
+REAL (kind=8)::  hthresh, htresh_ba !
+REAL (kind=8):: wrisk5dd1, wrisk5dd2, wrisk5dd3 !5-year wind risk of each damage density class
+REAL (kind=8)::  V_tot, vdam ! vol of all layers, site-level damaged vol
+REAL (kind=8):: BAdist(nLayers) !disturbed BA per layer
+
+
+
+
+
+
 
  real (kind=8), intent(in) :: defaultThin, ClCut, energyCut, yassoRun, fixBAinitClarcut  ! flags. Energy cuts takes harvest residues out from the forest.
  !!oldLayer scenario
@@ -141,11 +152,7 @@ real (kind=8) :: remhW_branch, remhW_croot,remhW_stem,remhWdb
 
 integer :: etmodel, gvRun, fertThin, ECMmod, oldLayer !not direct inputs anymore, but in prebasFlags fvec
 integer, intent(in) :: prebasFlags(6)
-REAL (kind=8)::  wrisk5, wrisk0, wrisk ! 5-year wind risk (suvanto output), pre-logit value, annual risk
-REAL (kind=8)::  wrisk_hdomlayers(nLayers), hthresh, htresh_ba !
-REAL (kind=8):: wrisk5dd1, wrisk5dd2, wrisk5dd3 !5-year wind risk of each damage density class
-REAL (kind=8)::  V_tot, vdam ! vol of all layers, site-level damaged vol
-REAL (kind=8):: BAdist(nLayers) !disturbed BA per layer
+
 
 
 

--- a/src/distSandboxWind.f90
+++ b/src/distSandboxWind.f90
@@ -4,34 +4,34 @@ subroutine windrisk(siteInfoDist, spec, h, openedge, sitetype, tsum, tsincethin,
   REAL (kind=8), intent(inout) ::  siteInfoDist(10) ! 5-year wind risk (suvanto output), pre-logit value, annual risk
   REAL (kind=8), intent(inout) ::  wrisk5, wrisk0, wrisk ! 5-year wind risk (suvanto output), pre-logit value, annual risk
   REAL (kind=8), intent(inout) :: wrisk5dd1, wrisk5dd2, wrisk5dd3 !5-year wind risk of each damage density class
-  REAL (kind=8), intent(in) :: h ! input in m, converted to dm 
-  REAL (kind=8), intent(in) :: tsum ! effective temperature sums (degree days over 5°C); converted to 100 dd 
+  REAL (kind=8), intent(in) :: h ! input in m, converted to dm
+  REAL (kind=8), intent(in) :: tsum ! effective temperature sums (degree days over 5°C); converted to 100 dd
   INTEGER, intent(in) :: spec !1 pine, 2 spruce, 3 other
   INTEGER, intent(in) :: openedge ! 0 = no open edge, 1 = open edge
-  INTEGER, intent(in) :: sitetype ! prebas site types; reclassified to site fertility: 0 = infertile, 1 = fertile 
+  INTEGER, intent(in) :: sitetype ! prebas site types; reclassified to site fertility: 0 = infertile, 1 = fertile
   REAL (kind=8) :: wspeed ! localised 10 a max windspeed (m/s), Venäläinen 2017
   INTEGER, intent(in) :: tsincethin ! time since last thinning in years, categorised into 0-5, 6-10, >10 below
   INTEGER :: soiltype ! 0 = mineral, coarse; 1 = mineral, fine; 2 = organic
   INTEGER :: shallowsoil ! 1 = <30cm
   INTEGER :: sitefert ! site fertility, reclassified from sitetype (1:3 fertile / 1, 4:5 infertile/0)
-  
+
   wspeed = siteInfoDist(1)
   !tsincethin = INT(siteInfoDist(2))
   soiltype = INT(siteInfoDist(3))
   shallowsoil = INT(siteInfoDist(4))
-  
+
     IF (sitetype <= 3) sitefert = 1 !convert sitetypes to fert class
     IF (sitetype > 3) sitefert = 0
 
     wrisk0 = -14.690 + &
                   LOG(h*10)*1.661 + &
-                  LOG(wspeed)*0.749 + & 
+                  LOG(wspeed)*0.749 + &
                   tsum/100*0.096 + &!effective temp sum (100 degree days)
                   openedge * 0.310 + &
                   shallowsoil * 0.214 - &
                   sitefert * 0.425
-      
-    !categorical variables with more than two levels externalised:              
+
+    !categorical variables with more than two levels externalised:
 
     !!! time since thinning; reference: 0-5a
     if (tsincethin>5 .AND. tsincethin <= 10) wrisk0 = wrisk0 - 0.298
@@ -52,14 +52,14 @@ subroutine windrisk(siteInfoDist, spec, h, openedge, sitetype, tsum, tsincethin,
     ! DAMAGE DENSITY (& logit transformation)
     ! spatial density of wind-disturbed NFI plots relative to all NFI plots
     !!! SEE SUPPLEMENTYRY INFO 1 of Suvanto et al. 2019
-    ! for prediction, the model is run for each damage density class individually 
+    ! for prediction, the model is run for each damage density class individually
     ! and a weighted average of the three is used; weights: damdens 0-2,2-3,>3: 0.905, 0.072, 0.023
 
     !damdens 0-2 (reference)
     wrisk5dd1 = EXP(wrisk0) / (1.0 + EXP(wrisk0)) ! logit transformation of reference
     !damdens 2-3
     wrisk0 = wrisk0 + 1.104
-    wrisk5dd2 = EXP(wrisk0) / (1.0 + EXP(wrisk0)) 
+    wrisk5dd2 = EXP(wrisk0) / (1.0 + EXP(wrisk0))
     !damdens >3
     wrisk0 = wrisk0 + 1.898 - 1.104 !to avoid another variable
     wrisk5dd3 = EXP(wrisk0) / (1.0 + EXP(wrisk0))
@@ -76,15 +76,15 @@ subroutine windriskold(spec, h, tsincethin, wspeed, openedge, soiltype, shallows
   IMPLICIT NONE
   REAL (kind=8), intent(inout) ::  wrisk5, wrisk0, wrisk ! 5-year wind risk (suvanto output), pre-logit value, annual risk
   REAL (kind=8), intent(inout) :: wrisk5dd1, wrisk5dd2, wrisk5dd3 !5-year wind risk of each damage density class
-  REAL (kind=8), intent(in) :: h ! input in m, converted to dm 
+  REAL (kind=8), intent(in) :: h ! input in m, converted to dm
   REAL (kind=8), intent(in) :: wspeed ! localised 10 a max windspeed (m/s), Venäläinen 2017
-  REAL (kind=8), intent(in) :: tsum ! effective temperature sums (degree days over 5°C); converted to 100 dd 
+  REAL (kind=8), intent(in) :: tsum ! effective temperature sums (degree days over 5°C); converted to 100 dd
   INTEGER, intent(in) :: spec !1 pine, 2 spruce, 3 other
   INTEGER, intent(in) :: tsincethin ! time since last thinning in years, categorised into 0-5, 6-10, >10 below
   INTEGER, intent(in) :: openedge ! 0 = no open edge, 1 = open edge
   INTEGER, intent(in) :: soiltype ! 0 = mineral, coarse; 1 = mineral, fine; 2 = organic
   INTEGER, intent(in) :: shallowsoil ! 1 = <30cm
-  INTEGER, intent(in) :: sitetype ! prebas site types; reclassified to site fertility: 0 = infertile, 1 = fertile 
+  INTEGER, intent(in) :: sitetype ! prebas site types; reclassified to site fertility: 0 = infertile, 1 = fertile
   INTEGER :: sitefert ! site fertility, reclassified from sitetype (1:3 fertile / 1, 4:5 infertile/0)
 
     IF (sitetype <= 3) sitefert = 1 !convert sitetypes to fert class
@@ -92,13 +92,13 @@ subroutine windriskold(spec, h, tsincethin, wspeed, openedge, soiltype, shallows
 
     wrisk0 = -14.690 + &
                   LOG(h*10)*1.661 + &
-                  LOG(wspeed)*0.749 + & 
+                  LOG(wspeed)*0.749 + &
                   tsum/100*0.096 + &!effective temp sum (100 degree days)
                   openedge * 0.310 + &
                   shallowsoil * 0.214 - &
                   sitefert * 0.425
 
-    !categorical variables with more than two levels externalised:              
+    !categorical variables with more than two levels externalised:
 
     !!! time since thinning; reference: 0-5a
     if (tsincethin>5 .AND. tsincethin <= 10) wrisk0 = wrisk0 - 0.298
@@ -119,14 +119,14 @@ subroutine windriskold(spec, h, tsincethin, wspeed, openedge, soiltype, shallows
     ! DAMAGE DENSITY (& logit transformation)
     ! spatial density of wind-disturbed NFI plots relative to all NFI plots
     !!! SEE SUPPLEMENTYRY INFO 1 of Suvanto et al. 2019
-    ! for prediction, the model is run for each damage density class individually 
+    ! for prediction, the model is run for each damage density class individually
     ! and a weighted average of the three is used; weights: damdens 0-2,2-3,>3: 0.905, 0.072, 0.023
 
     !damdens 0-2 (reference)
     wrisk5dd1 = EXP(wrisk0) / (1.0 + EXP(wrisk0)) ! logit transformation of reference
     !damdens 2-3
     wrisk0 = wrisk0 + 1.104
-    wrisk5dd2 = EXP(wrisk0) / (1.0 + EXP(wrisk0)) 
+    wrisk5dd2 = EXP(wrisk0) / (1.0 + EXP(wrisk0))
     !damdens >3
     wrisk0 = wrisk0 + 1.898 - 1.104 !to avoid another variable
     wrisk5dd3 = EXP(wrisk0) / (1.0 + EXP(wrisk0))
@@ -142,34 +142,34 @@ end subroutine
 
 ! subroutine prioritiseDistReact(siteOrder, outDist, nsites)
 !   IMPLICIT NONE
-!   REAL (kind=8), intent(inout) ::  outDist(nSites, 10) 
+!   REAL (kind=8), intent(inout) ::  outDist(nSites, 10)
 !   INTEGER, intent(inout) ::  siteOrder(nSites)
 !   INTEGER, intent(in) :: nSites !1 pine, 2 spruce, 3 o
-! 
-! 
+!
+!
 ! do i = 1, nSites
 !   if (outDist(i, 7) == 1) then
 !     siteOrder()
-! 
-! 
+!
+!
 ! end do
-! 
-! 
+!
+!
 ! end subroutine
-! 
-! ! 
+!
+! !
 ! subroutine move_element_to_front(vector, index, n)
 !     implicit none
 !     integer, intent(inout) :: vector(:)
 !     integer, intent(in) :: index, n
 !     integer :: temp, i
-! 
+!
 !     ! Check if index is valid
 !     if (index < 1 .or. index > n) then
 !         print *, "Error: Index out of bounds"
 !         return
 !     end if
-! 
+!
 !     ! Move the element to the front
 !     temp = vector(index)
 !     do i = index, 2, -1
@@ -194,10 +194,10 @@ subroutine move_element_to_front(siteorder, index, nsites, siteordertemp)
 
     ! Move the element to the front
     siteordertemp(1) = siteorder(index) ! put focus site id to top
-    do i = 1, index-1 ! shift all siteids in siteorder prior to index one down 
+    do i = 1, index-1 ! shift all siteids in siteorder prior to index one down
         siteordertemp(i+1) = siteorder(i)
     end do
-    siteordertemp((index+1):nsites) = siteorder((index+1):nsites) ! keep remaining siteorder as is 
+    siteordertemp((index+1):nsites) = siteorder((index+1):nsites) ! keep remaining siteorder as is
     !vector(1) = temp
 end subroutine move_element_to_front
 
@@ -215,13 +215,13 @@ real (kind=8), intent(inout) :: poutdist(nsites, 10)
 
     ! Move the element to the front
     siteordertemp(1) = siteorder(index(1)) ! put focus site id to top
-    do i = 1, index(1)-1 ! shift all siteids in siteorder prior to index one down 
+    do i = 1, index(1)-1 ! shift all siteids in siteorder prior to index one down
         siteordertemp(i+1) = siteorder(i)
     end do
-    siteordertemp((index(1)+1):nsites) = siteorder((index(1)+1):nsites) ! keep remaining siteorder as is 
+    siteordertemp((index(1)+1):nsites) = siteorder((index(1)+1):nsites) ! keep remaining siteorder as is
 end subroutine move_siteid_to_top
 
-! 
+!
 ! subroutine move_siteid_to_top2(siteorder, siteid, nsites, siteordertemp, poutdist)
 !     implicit none
 !     integer, intent(inout) :: siteorder(nsites)
@@ -229,31 +229,31 @@ end subroutine move_siteid_to_top
 !     integer :: temp, i, index(1), priosites(nsites), nsitesdist,  siteid
 !     integer, intent(inout) :: siteordertemp(nsites)
 ! real (kind=8), intent(inout) :: poutdist(nsites, 10)
-! 
+!
 !   ! here: finding siteids of distcc-earmarked sites
-!   ! for now limited to a single site 
-! 
+!   ! for now limited to a single site
+!
 !     !nsitesdist = sum(poutdist(:,7))
-! 
+!
 !      priosites = findloc(poutdist(:,7), 1)
-! 
+!
 !     siteid = priosites(1)
-! 
-! 
+!
+!
 !     ! below working if siteid is given
 !     !index = findloc(siteorder, siteid) !find location of siteid in question within siteorder
 !     siteordertemp = abs(siteorder-siteid)
 !     index = minloc(siteordertemp(:)) !find location of siteid in question within siteorder !! findloc only in fortran 2008 and later, workaround with abs/minloc
-! 
+!
 !     ! Move the element to the front
 !     siteordertemp(1) = siteorder(index(1)) ! put focus site id to top
-!     do i = 1, index(1)-1 ! shift all siteids in siteorder prior to index one down 
+!     do i = 1, index(1)-1 ! shift all siteids in siteorder prior to index one down
 !         siteordertemp(i+1) = siteorder(i)
 !     end do
-!     siteordertemp((index(1)+1):nsites) = siteorder((index(1)+1):nsites) ! keep remaining siteorder as is 
-! 
+!     siteordertemp((index(1)+1):nsites) = siteorder((index(1)+1):nsites) ! keep remaining siteorder as is
+!
 !     nsites = siteid
-! 
+!
 ! end subroutine move_siteid_to_top2
 
 subroutine find_row_indexes(matrix, n, row_indexes)
@@ -262,7 +262,7 @@ subroutine find_row_indexes(matrix, n, row_indexes)
     integer, intent(in) :: n
     integer, intent(inout) :: row_indexes(n)
     integer :: i, count
-    
+
     count = 0
     do i = 1, n
         if (INT(matrix(i, 7)) == 1) then
@@ -270,7 +270,7 @@ subroutine find_row_indexes(matrix, n, row_indexes)
             row_indexes(count) = i
         end if
     end do
-    
+
     ! Fill remaining elements of row_indexes with 0
     do i = count + 1, n
         row_indexes(i) = 0
@@ -278,9 +278,9 @@ subroutine find_row_indexes(matrix, n, row_indexes)
 end subroutine find_row_indexes
 
 
-!subroutine prioDistInSO(outDist, nSites, siteOrder, siteOrderX)
 subroutine prioDistInSO(outDist, nSites, maxYears, year, siteOrder)
-
+! prioritise sites flagged for management reaction to wind disturbance in siteOrder (annualy randomised site order)
+! puts sites flagged for mgmt reaction to disturbance in last year's outDist on top of site order
     implicit none
     integer, intent(in) :: nSites, year, maxYears
     integer, intent(inout) :: siteOrder(nSites,maxYears)! , siteOrderX(nSites)
@@ -288,7 +288,7 @@ subroutine prioDistInSO(outDist, nSites, maxYears, year, siteOrder)
     integer :: sitexx, distpriositexx, ndistprio, temp, index(1), siteid, siteordertemp(nSites), priosites(nSites)
     ! fill priosites with siteids (outdist in 1:nsites order)
     ndistprio = 0
-    
+
     do sitexx = 1, nSites
         if (outDist(sitexx, 8) == 1.) then
             ndistprio = ndistprio + 1
@@ -297,17 +297,17 @@ subroutine prioDistInSO(outDist, nSites, maxYears, year, siteOrder)
     end do
     ! for each of these, put siteid on top and shift those siteids above in sitorder one down
     !write(1,*) ndistprio !tswrite
-    ! siteOrder(2,year) = ndistprio !troubleshooting: 
+    ! siteOrder(2,year) = ndistprio !troubleshooting:
     do distpriositexx = 1, ndistprio
-      siteid = priosites(distpriositexx)  
+      siteid = priosites(distpriositexx)
           siteordertemp = abs(siteOrder(:,year)-siteid)
            index = minloc(siteordertemp(:)) !find location of siteid in question within siteorder !! findloc only in fortran 2008 and later, workaround with abs/minloc
           ! Move the element to the front
           siteordertemp(1) = siteOrder(index(1), year) ! put focus site id to top
-          do sitexx = 1, index(1)-1 ! shift all siteids in siteorder prior to index one down 
+          do sitexx = 1, index(1)-1 ! shift all siteids in siteorder prior to index one down
               siteordertemp(sitexx+1) = siteOrder(sitexx, year)
           end do
-          siteordertemp((index(1)+1):nsites) = siteOrder((index(1)+1):nsites, year) ! keep remaining siteorder as is 
+          siteordertemp((index(1)+1):nsites) = siteOrder((index(1)+1):nsites, year) ! keep remaining siteorder as is
           !siteOrder(1,year) = year+1
 
           siteOrder(:,year) = siteordertemp(:)
@@ -315,28 +315,3 @@ subroutine prioDistInSO(outDist, nSites, maxYears, year, siteOrder)
     ! to see if anything happening here is in output
 
       end subroutine prioDistInSO
-    
-    
-    
-    
-    
-    
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/src/disturbanceCalc.h
+++ b/src/disturbanceCalc.h
@@ -57,13 +57,14 @@ do i = 1, nLayers
   INT(siteInfoDist(2)), wrisk5dd1,wrisk5dd2,wrisk5dd3,wrisk0,wrisk5,wrisk)
   htresh_ba =  htresh_ba+STAND_all(13,i) !collect ba of layers within htresh height range
 wrisk_hdomlayers(i) = wrisk*STAND_all(13,i) !weigh wind risk by layer ba
- outDist(year,3) = sum(wrisk_hdomlayers(:))/htresh_ba
+
  ! for development of wrisk of co-dominant layers
 outDist(year,1) = wrisk_hdomlayers(1)/STAND_all(13,1) ! layer 1 un-weighed wrisk
 outDist(year,2) = wrisk_hdomlayers(2)/STAND_all(13,2) ! layer 2 un-weighed wrisk
 outDist(year,10) = wrisk_hdomlayers(3)/STAND_all(13,3) ! layer 3 un-weighed wrisk
  end if
   end do
+  outDist(year,3) = sum(wrisk_hdomlayers(:))/htresh_ba
 !!! END DRAFT
 !! WINDRISK SUBROUTINE
 !!call windrisk(siteInfoDist, spec, h, openedge, sitetype, tsum, &

--- a/src/disturbanceCalc.h
+++ b/src/disturbanceCalc.h
@@ -39,37 +39,45 @@ wdistproc(:) = 0.
 
 ! UPDATE: version considering layer with largest H as well as those within a 5m range
 ! to better account for effect of mixtures
+ ! real (kind=8) :: wdistproc(7) !to replace siteinfodist
 ! DRAFT:
 !real (kind=8)::wrisk_hdomlayers(nLayers), hthresh, htresh_ba !
-
 hthresh = (maxval(STAND_all(11,:))-5)
-htresh_ba = 0.
+htresh_ba = 0
 do i = 1, nLayers
    if(STAND_all(11,i) > hthresh) THEN
-       ! setting wrisks to 0 (subroutine inout), to be simplified
-        wrisk5dd1 = 0
-        wrisk5dd2 = 0
-        wrisk5dd3 = 0
-        wrisk0 = 0
-        wrisk5 = 0
-        wrisk = 0
-        call windrisk(siteInfoDist, INT(STAND_all(4,i)), STAND_all(11,i), 0, INT(STAND_all(3,1)), STAND_all(5,1), &
-        INT(siteInfoDist(2)), wrisk5dd1,wrisk5dd2,wrisk5dd3,wrisk0,wrisk5,wrisk)
-        htresh_ba =  htresh_ba+STAND_all(13,i) !collect ba of layers within htresh height range
-        wriskLayers(i,1) = wrisk*STAND_all(13,i) !weigh wind risk by layer ba
-      !  ! for development of wrisk of co-dominant layers
-      ! outDist(year,1) = wrisk_hdomlayers(1)/STAND_all(13,1) ! layer 1 un-weighed wrisk
-      ! outDist(year,2) = wrisk_hdomlayers(2)/STAND_all(13,2) ! layer 2 un-weighed wrisk
-      ! outDist(year,10) = wrisk_hdomlayers(3)/STAND_all(13,3) ! layer 3 un-weighed wrisk
-
+ ! setting wrisks to 0 (subroutine inout), to be simplified
+  wrisk5dd1 = 0
+  wrisk5dd2 = 0
+  wrisk5dd3 = 0
+  wrisk0 = 0
+  wrisk5 = 0
+  wrisk = 0
+  call windrisk(siteInfoDist, INT(STAND_all(4,i)), STAND_all(11,i), 0, STAND_all(3,1), STAND_all(5,1), &
+  INT(siteInfoDist(2)), wrisk5dd1,wrisk5dd2,wrisk5dd3,wrisk0,wrisk5,wrisk)
+  htresh_ba =  htresh_ba+STAND_all(13,i) !collect ba of layers within htresh height range
+wrisk_hdomlayers(i) = wrisk*STAND_all(13,i) !weigh wind risk by layer ba
+ outDist(year,3) = sum(wrisk_hdomlayers(:))/htresh_ba
+ ! for development of wrisk of co-dominant layers
+outDist(year,1) = wrisk_hdomlayers(1)/STAND_all(13,1) ! layer 1 un-weighed wrisk
+outDist(year,2) = wrisk_hdomlayers(2)/STAND_all(13,2) ! layer 2 un-weighed wrisk
+outDist(year,10) = wrisk_hdomlayers(3)/STAND_all(13,3) ! layer 3 un-weighed wrisk
  end if
   end do
+!!! END DRAFT
+!! WINDRISK SUBROUTINE
+!!call windrisk(siteInfoDist, spec, h, openedge, sitetype, tsum, &
+!!  wrisk5dd1, wrisk5dd2, wrisk5dd3, wrisk0, wrisk5, wrisk)
+!call windrisk(siteInfoDist, INT(wdistproc(2)), wdistproc(3), 0, STAND_all(3,1), STAND_all(5,1), INT(siteInfoDist(2)), &
+!  wrisk5dd1,wrisk5dd2,wrisk5dd3,wrisk0,wrisk5,wrisk)
 
-!!! END multi-layer site level wind risk estimation
-outDist(year,1) = wdistproc(2) ! dom spec
-outDist(year,2) = siteInfoDist(2) !tsincethin
-outDist(year,3) = sum(wriskLayers(:,1))/htresh_ba
+!assigning risks
 
+!outDist(year,1) = wdistproc(2) ! dom spec
+!outDist(year,2) = siteInfoDist(2) !tsincethin
+!outDist(year,3) = wrisk !1a
+
+!!!! ABOVE: REPLACED BY DRAFT
 
 !!!!!!! WIND DISTURBANCE IMPACT MODELLING !!!!!!!!!!
 ! basic idea: 3-step sampling
@@ -185,6 +193,9 @@ if (outDist(year,4)>0.) then !in case of disturbance
       outDist(year,7) = 1. !indicate salvage logging in output
     endif
   endif
+
+
+
 
   ! MGMT REACTION / PRIORITISATION IN SITEORDER
   if(vdam>=siteInfoDist(8)) then

--- a/src/disturbanceCalc.h
+++ b/src/disturbanceCalc.h
@@ -36,7 +36,7 @@
 
 
 wdistproc(:) = 0.
-
+wriskLayers(:,:) = 0.
 ! UPDATE: version considering layer with largest H as well as those within a 5m range
 ! to better account for effect of mixtures
  ! real (kind=8) :: wdistproc(7) !to replace siteinfodist
@@ -56,15 +56,23 @@ do i = 1, nLayers
   call windrisk(siteInfoDist, INT(STAND_all(4,i)), STAND_all(11,i), 0, STAND_all(3,1), STAND_all(5,1), &
   INT(siteInfoDist(2)), wrisk5dd1,wrisk5dd2,wrisk5dd3,wrisk0,wrisk5,wrisk)
   htresh_ba =  htresh_ba+STAND_all(13,i) !collect ba of layers within htresh height range
-wrisk_hdomlayers(i) = wrisk*STAND_all(13,i) !weigh wind risk by layer ba
+wriskLayers(i,1) = wrisk*STAND_all(13,i) !weigh wind risk by layer ba
 
- ! for development of wrisk of co-dominant layers
-outDist(year,1) = wrisk_hdomlayers(1)/STAND_all(13,1) ! layer 1 un-weighed wrisk
-outDist(year,2) = wrisk_hdomlayers(2)/STAND_all(13,2) ! layer 2 un-weighed wrisk
-outDist(year,10) = wrisk_hdomlayers(3)/STAND_all(13,3) ! layer 3 un-weighed wrisk
+
  end if
   end do
-  outDist(year,3) = sum(wrisk_hdomlayers(:))/htresh_ba
+
+  ! for development of wrisk of co-dominant layers
+
+  outDist(year,1) = wriskLayers(1,1)/STAND_all(13,1) ! layer 1 un-weighed wrisk
+  outDist(year,2) = wriskLayers(2,1)/STAND_all(13,2) ! layer 2 un-weighed wrisk
+  outDist(year,10) = wriskLayers(3,1)/STAND_all(13,3) ! layer 3 un-weighed wrisk
+
+if(htresh_ba>0.) then
+  outDist(year,3) = sum(wriskLayers(:,1))/htresh_ba
+else
+  outDist(year,3) = 0.
+endif
 !!! END DRAFT
 !! WINDRISK SUBROUTINE
 !!call windrisk(siteInfoDist, spec, h, openedge, sitetype, tsum, &
@@ -219,7 +227,7 @@ if (outDist(year,4)>0.) then !in case of disturbance
 endif ! end salvlog/mgmtrect module
 
 
- outDist(year,10) = clcut
+ !outDist(year,10) = clcut
 
 if(clCut<0.) then !blocking mgmt reactions in sites indicated as preservation/unmanaged
   pHarvTrees = 0.

--- a/src/disturbanceCalc.h
+++ b/src/disturbanceCalc.h
@@ -6,7 +6,7 @@
 !   siteInfoDist: wspeed, tsincethin, soiltype, shallowsoil
 !   dom layer spec, h
 !   sitetype, tempsum
-!   tsincethin counter reset by manual & tapio thinnings (tested), compensation thinnings (untested) 
+!   tsincethin counter reset by manual & tapio thinnings (tested), compensation thinnings (untested)
 !   NOTE: openedge (at least one neighbouring stand <5m) currently not implemented
 !         postponed, requires dynamic spacially explicit info (e.g. via lookup table)
 
@@ -35,31 +35,32 @@
 ! //END single highest layer wind risk estimation
 
 
-wdistproc(:) = 0
+wdistproc(:) = 0.
 
 ! UPDATE: version considering layer with largest H as well as those within a 5m range
 ! to better account for effect of mixtures
-! DRAFT: 
+! DRAFT:
 !real (kind=8)::wrisk_hdomlayers(nLayers), hthresh, htresh_ba !
+
 hthresh = (maxval(STAND_all(11,:))-5)
-htresh_ba = 0
+htresh_ba = 0.
 do i = 1, nLayers
    if(STAND_all(11,i) > hthresh) THEN
- ! setting wrisks to 0 (subroutine inout), to be simplified
-  wrisk5dd1 = 0
-  wrisk5dd2 = 0
-  wrisk5dd3 = 0
-  wrisk0 = 0
-  wrisk5 = 0
-  wrisk = 0
-  call windrisk(siteInfoDist, INT(STAND_all(4,i)), STAND_all(11,i), 0, STAND_all(3,1), STAND_all(5,1), &
-  INT(siteInfoDist(2)), wrisk5dd1,wrisk5dd2,wrisk5dd3,wrisk0,wrisk5,wrisk)
-  htresh_ba =  htresh_ba+STAND_all(13,i) !collect ba of layers within htresh height range
-  wriskLayers(i,1) = wrisk*STAND_all(13,i) !weigh wind risk by layer ba
-!  ! for development of wrisk of co-dominant layers
-! outDist(year,1) = wrisk_hdomlayers(1)/STAND_all(13,1) ! layer 1 un-weighed wrisk
-! outDist(year,2) = wrisk_hdomlayers(2)/STAND_all(13,2) ! layer 2 un-weighed wrisk
-! outDist(year,10) = wrisk_hdomlayers(3)/STAND_all(13,3) ! layer 3 un-weighed wrisk
+       ! setting wrisks to 0 (subroutine inout), to be simplified
+        wrisk5dd1 = 0
+        wrisk5dd2 = 0
+        wrisk5dd3 = 0
+        wrisk0 = 0
+        wrisk5 = 0
+        wrisk = 0
+        call windrisk(siteInfoDist, INT(STAND_all(4,i)), STAND_all(11,i), 0, INT(STAND_all(3,1)), STAND_all(5,1), &
+        INT(siteInfoDist(2)), wrisk5dd1,wrisk5dd2,wrisk5dd3,wrisk0,wrisk5,wrisk)
+        htresh_ba =  htresh_ba+STAND_all(13,i) !collect ba of layers within htresh height range
+        wriskLayers(i,1) = wrisk*STAND_all(13,i) !weigh wind risk by layer ba
+      !  ! for development of wrisk of co-dominant layers
+      ! outDist(year,1) = wrisk_hdomlayers(1)/STAND_all(13,1) ! layer 1 un-weighed wrisk
+      ! outDist(year,2) = wrisk_hdomlayers(2)/STAND_all(13,2) ! layer 2 un-weighed wrisk
+      ! outDist(year,10) = wrisk_hdomlayers(3)/STAND_all(13,3) ! layer 3 un-weighed wrisk
 
  end if
   end do
@@ -83,10 +84,10 @@ if(rndm <= wrisk) outDist(year,4) = 1 !wind disturbance occurs/ set severity cla
 if(rndm > wrisk) outDist(year,4) = 0 !... or doesn't.
 
 !step 2: severity class (for now with shares/probabilities from post-storm inventory )
-if (outDist(year,4)==1) then 
+if (outDist(year,4)==1) then
   call random_number(rndm) ! leave sevclass at 1 or increase based on sampling
-  !outDist(year,8) = 1 !set sevclass to 1 
-  if(rndm <= 0.13888889) outDist(year,4) = 2 
+  !outDist(year,8) = 1 !set sevclass to 1
+  if(rndm <= 0.13888889) outDist(year,4) = 2
   if(rndm <= 0.05555556) outDist(year,4) = 3 !these are now sampled even if there's no disturbance occuring; keep for dev purposes, only calculate when dist occurres in final version
 endif
 
@@ -132,10 +133,10 @@ endif
 ! wriskLayers(:,:) = 0
 ! IF(outDist(year,4) >0 .AND. nLayers>1) THEN !if there's a wind disturbance and more than one layer
 !   do i = 1, nLayers !loop through them
-!      if (STAND_all(11,i) > (wdistproc(3)-5)) then !within 5 m of highest layer (which the total wind risk is based on) !!! 
+!      if (STAND_all(11,i) > (wdistproc(3)-5)) then !within 5 m of highest layer (which the total wind risk is based on) !!!
 !      call windrisk(siteInfoDist, INT(STAND_all(4,i)), STAND_all(11,i), 0, STAND_all(3,1), STAND_all(5,1),  INT(siteInfoDist(2)), & !calculate layer wind risk
 !        wrisk5dd1,wrisk5dd2,wrisk5dd3,wrisk0,wrisk5,wrisk)
-!        wriskLayers(i, 1) = wrisk  
+!        wriskLayers(i, 1) = wrisk
 !      end if
 !   end do
 ! end if
@@ -146,7 +147,7 @@ V_tot = sum(STAND_all(30,:))
 
 vdam = wdistproc(4)*V_tot
 
-if(outDist(year, 4)>0) then 
+if(outDist(year, 4)>0) then
   outDist(year, 5) = vdam
   outDist(year, 6) = wdistproc(4)
 endif
@@ -154,8 +155,8 @@ endif
 wriskLayers(:, 2) = STAND_all(30,:)*wriskLayers(:,1) !weighing factor for vol 'at risk': if layer-level risk and volume are equal across layers, all would receive the same amount of damage; otherwise weighed by risk AND volume share
 wriskLayers(:, 3) = wriskLayers(:, 2) / sum(wriskLayers(:, 2)) !shares of disturbwd volumes
 !wriskLayers(:, 4) = wriskLayers(:,2)*wriskLayers(:,3) !share of potentially affected V !! attention: doesn't add up to 1, this is too simple
-! better: 
-wriskLayers(:, 4) = vdam * wriskLayers(:, 3)  ! plot-level damaged volume allocated to layers 
+! better:
+wriskLayers(:, 4) = vdam * wriskLayers(:, 3)  ! plot-level damaged volume allocated to layers
 wriskLayers(:, 5) = STAND_all(30,:)/STAND_all(13,:)!V per ba
 wriskLayers(:, 6) = wriskLayers(:, 4)/wriskLayers(:,5)! convert affected vol to affected ba
 
@@ -172,14 +173,14 @@ end do
 
 !!!! MANAGEMENT REACTION / SALVAGE LOGGING
 
-if (outDist(year,4)>0.) then !in case of disturbance 
+if (outDist(year,4)>0.) then !in case of disturbance
   pHarvTrees = 0.
 
   ! SALVAGE LOGGING
   if(vdam>=siteInfoDist(5)) then ! threshold for salvage logging
-    siteInfoDist(2) = 0 ! reset thinning counter, i.e. wind disturbance temporarily increases wind risk 
+    siteInfoDist(2) = 0 ! reset thinning counter, i.e. wind disturbance temporarily increases wind risk
     call random_number(rndm)
-    if(rndm<=siteInfoDist(6)) then 
+    if(rndm<=siteInfoDist(6)) then
       pHarvTrees = siteInfoDist(7)! if sampled for salvlog set pHarvTrees
       outDist(year,7) = 1. !indicate salvage logging in output
     endif
@@ -202,7 +203,7 @@ if (outDist(year,4)>0.) then !in case of disturbance
        outDist(year,9) = 1. !indicate clearcut
        outDist(year,8) = 1. !mgmtreact = T in order to include cc harvests towards meeting harvlim (and not after it's been met if lower in siteorder...)
     endif
-  endif  
+  endif
 endif ! end salvlog/mgmtrect module
 
 
@@ -217,8 +218,8 @@ endif
 !!!! UPDATING STAND VARS !!!!
 ! based on Francesco's code, only inputs necessary: layer level killed BA & pHarvTrees
  if(.TRUE.) then !if XX everything is switch off for the moment !wdimp x1
- ! 
- ! !!!!!check litterfall!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! 
+ !
+ ! !!!!!check litterfall!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
   if (disturbanceON) then !x2
    ! BAmort = 0.d0
    ! pMort = 0.2d0
@@ -227,7 +228,7 @@ endif
  !   call pDistTest(ETS,1200.0d0,pMort) !!!calculate probability of fire to occur in this stand
  !   call random_number(randX)
  !   if(randX < pMort)  call intTest(pMort,perBAmort) !!!calculate the intensity of possible fire of fire to occur in this stand
- ! 
+ !
  ! ! calculate probability of the disturbance to occur and
  ! ! the intensity of the disturbance
  !   perBAmort = 0. ! deactivate Francesco's randomised mortality, seems to be very active and reduces n < 1 over rotation
@@ -241,7 +242,7 @@ endif
      ! perBAmort = 0.1
        ! write(1,*) "disturbance", year, pMort, perBAmort
    do ij = 1 , nLayers     !loop Species xl1
-    
+
     BAmort = BAdist(ij)
     dN=0.d0
     STAND=STAND_all(:,ij)
@@ -290,12 +291,12 @@ endif
     par_fAb = param(46)
     par_fAc = param(47)
 
-     !!!!update kRein and cR   
-    !!!!update par_kRein as a function of sitetype if parameters (param(50>-999.))) are are provided 
-    if(param(50)>-999.d0) call linearUpdateParam(param(50:51),stand(3),par_kRein) 
-    !!!!update par_cR as a function of sitetype if parameters (param(52>-999.))) are are provided 
-    if(param(52)>-999.d0) call linearUpdateParam(param(52:53),stand(3),par_cR) 
-!activate 
+     !!!!update kRein and cR
+    !!!!update par_kRein as a function of sitetype if parameters (param(50>-999.))) are are provided
+    if(param(50)>-999.d0) call linearUpdateParam(param(50:51),stand(3),par_kRein)
+    !!!!update par_cR as a function of sitetype if parameters (param(52>-999.))) are are provided
+    if(param(52)>-999.d0) call linearUpdateParam(param(52:53),stand(3),par_cR)
+!activate
    if (year > maxYearSite) then !x4
      STAND(2) = 0. !!newX
      STAND(8:21) = 0. !#!#
@@ -349,12 +350,12 @@ endif
 !      if(BAmort(ij) > 0. .and. maxval(wriskLayers(:,1)) == 0) then !check if mortality occurs UPDATE: only activated if there is no wind disturbance wdimp
       !dN = -Nold * (BAmort/(BA/BAr(ij)))
      dN = -Nold * (BAmort/BA)
-     
+
     ! elseif(maxval(wriskLayers(:,1)) > 0) then !wdimp define dN based on layer-level disturbed ba
     ! !  dN = -Nold * (BAmort/(BA/BAr(ij)))
     !   dN = -Nold * (wriskLayers(ij,6)/BA) !disturbed layer ba/layer ba
     else
-      dN = 0.  
+      dN = 0.
      endif
 
    !!!update variables
@@ -412,11 +413,11 @@ endif
 !! allocating salvage logging to current (regionPrebas harvlimit not met when site is checked or all mgmt switched off) or next year (some mgmt allowed / harvlimit exceeded)
 if(ClCut == 0. .and. defaultThin == 0.) then ! either mgmt switched off entirely or blocked due to harvest limit being met
     outt(42,ij,2) = outt(30,ij,2) + max((Vold-V)*pHarvTrees,0.)*harvRatio !salvnext save salvlogged layer-level vol here to be included in next year's harvest limit in regionPrebas (harvRatio otherwise applied when going from ,,30,,2 to ,,37,,1)
-elseif(ClCut > 0. .or. defaultThin > 0.) then 
+elseif(ClCut > 0. .or. defaultThin > 0.) then
     outt(30,ij,2) = outt(30,ij,2) + max((Vold-V)*pHarvTrees,0.)
 endif
     !!!
-    
+
   endif !x6
 
      STAND(11) = H
@@ -435,9 +436,8 @@ endif !x4
     STAND_all(:,ij)=STAND
     end do !!!!!!!end loop layers xl1
  endif !bamort>0... x3
-!  ! 
+!  !
  endif !if disturbanceON x2
 !  ! ! endif
 endif !end if XX switch off the modules x1
- ! 
-
+ !


### PR DESCRIPTION
Site-level wind risk based on multiple H-dominant layers (within 5m from max height). In addition: wind disturbance over salvage logging threshold sets time-since-thinning-counter to 0, i.e. temporarily increases wind risk.